### PR TITLE
Critical extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ data
 doc
 composer.lock
 ./.php_cs
+tools/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ data
 ./certs
 doc
 composer.lock
+./.php_cs

--- a/.php_cs
+++ b/.php_cs
@@ -2,7 +2,8 @@
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . "/src")
-    ->in(__DIR__ . "/tests");
+    ->in(__DIR__ . "/tests")
+    ->in(__DIR__ . "/tools");
 
 return PhpCsFixer\Config::create()
     ->setRules([

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": ">=7.1",
         "guzzlehttp/guzzle": "^6.3",
         "fgrosse/phpasn1": "^2.1",
-        "phpunit/phpunit": "^7"
+        "phpunit/phpunit": "^7",
+        "sop/asn1": "^3.4"
     },
     "license": "GPL-2.0-or-later",
     "authors": [

--- a/src/Certificate/AuthorityKeyIdentifier.php
+++ b/src/Certificate/AuthorityKeyIdentifier.php
@@ -3,8 +3,7 @@
 namespace eIDASCertificate\Certificate;
 
 use eIDASCertificate\Certificate\ExtensionInterface;
-use eIDASCertificate\OID;
-use FG\ASN1\ASNObject;
+use eIDASCertificate\CertificateException;
 
 /**
  *
@@ -12,13 +11,20 @@ use FG\ASN1\ASNObject;
  class AuthorityKeyIdentifier implements ExtensionInterface
  {
      private $binary;
+     private $keyIdentifier;
+
      const type = 'authorityKeyIdentifier';
      const oid = '2.5.29.35';
      const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.1';
 
      public function __construct($asn1Extension)
      {
-         $this->binary = ASNObject::fromBinary($asn1Extension);
+         if (strlen($asn1Extension) == 24) {
+             // SHA-1
+             $this->keyIdentifier = substr($asn1Extension, 4);
+         } else {
+             throw new CertificateException("Unsupported keyId length for authorityKeyIdentifier", 1);
+         }
      }
 
      public function getType()
@@ -34,5 +40,10 @@ use FG\ASN1\ASNObject;
      public function getBinary()
      {
          return $this->binary;
+     }
+
+     public function getKeyId()
+     {
+         return $this->keyIdentifier;
      }
  }

--- a/src/Certificate/AuthorityKeyIdentifier.php
+++ b/src/Certificate/AuthorityKeyIdentifier.php
@@ -10,24 +10,24 @@ use FG\ASN1\ASNObject;
  *
  */
  class AuthorityKeyIdentifier implements ExtensionInterface
-{
-    private $binary;
-    const type = 'authorityKeyIdentifier';
-    const oid = '2.5.29.35';
-    const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.1';
+ {
+     private $binary;
+     const type = 'authorityKeyIdentifier';
+     const oid = '2.5.29.35';
+     const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.1';
 
-    public function __construct($asn1Extension)
-    {
-        $this->binary = ASNObject::fromBinary($asn1Extension);
-    }
+     public function __construct($asn1Extension)
+     {
+         $this->binary = ASNObject::fromBinary($asn1Extension);
+     }
 
-    public function getType()
-    {
-        return self::type;
-    }
+     public function getType()
+     {
+         return self::type;
+     }
 
-    public function getURI()
-    {
-        return self::uri;
-    }
-}
+     public function getURI()
+     {
+         return self::uri;
+     }
+ }

--- a/src/Certificate/AuthorityKeyIdentifier.php
+++ b/src/Certificate/AuthorityKeyIdentifier.php
@@ -30,4 +30,9 @@ use FG\ASN1\ASNObject;
      {
          return self::uri;
      }
+
+     public function getBinary()
+     {
+         return $this->binary;
+     }
  }

--- a/src/Certificate/AuthorityKeyIdentifier.php
+++ b/src/Certificate/AuthorityKeyIdentifier.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace eIDASCertificate\Certificate;
+
+use eIDASCertificate\Certificate\ExtensionInterface;
+use eIDASCertificate\OID;
+use FG\ASN1\ASNObject;
+
+/**
+ *
+ */
+ class AuthorityKeyIdentifier implements ExtensionInterface
+{
+    private $binary;
+    const type = 'authorityKeyIdentifier';
+    const oid = '2.5.29.35';
+    const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.1';
+
+    public function __construct($asn1Extension)
+    {
+        $this->binary = ASNObject::fromBinary($asn1Extension);
+    }
+
+    public function getType()
+    {
+        return self::type;
+    }
+
+    public function getURI()
+    {
+        return self::uri;
+    }
+}

--- a/src/Certificate/BasicConstraints.php
+++ b/src/Certificate/BasicConstraints.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace eIDASCertificate\Certificate;
+
+use eIDASCertificate\Certificate\ExtensionInterface;
+use eIDASCertificate\OID;
+use FG\ASN1\ASNObject;
+
+/**
+ *
+ */
+ class BasicConstraints implements ExtensionInterface
+{
+    private $binary;
+    const type = 'basicConstraints';
+    const oid = '2.5.29.19';
+    const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.9';
+
+    public function __construct($asn1Extension)
+    {
+
+    }
+
+    public function getType()
+    {
+        return self::type;
+    }
+
+    public function getURI()
+    {
+        return self::uri;
+    }
+}

--- a/src/Certificate/BasicConstraints.php
+++ b/src/Certificate/BasicConstraints.php
@@ -56,4 +56,9 @@ use FG\ASN1\ASNObject;
              return false;
          }
      }
+
+     public function getBinary()
+     {
+         return $this->binary;
+     }
  }

--- a/src/Certificate/BasicConstraints.php
+++ b/src/Certificate/BasicConstraints.php
@@ -3,6 +3,7 @@
 namespace eIDASCertificate\Certificate;
 
 use eIDASCertificate\Certificate\ExtensionInterface;
+use eIDASCertificate\Certificate\ExtensionException;
 use eIDASCertificate\OID;
 use FG\ASN1\ASNObject;
 
@@ -10,24 +11,49 @@ use FG\ASN1\ASNObject;
  *
  */
  class BasicConstraints implements ExtensionInterface
-{
-    private $binary;
-    const type = 'basicConstraints';
-    const oid = '2.5.29.19';
-    const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.9';
+ {
+     private $binary;
+     private $pathLength;
+     private $isCA;
+     const type = 'basicConstraints';
+     const oid = '2.5.29.19';
+     const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.9';
 
-    public function __construct($asn1Extension)
-    {
+     public function __construct($asn1Extension)
+     {
+         $constraints = ASNObject::fromBinary($asn1Extension);
+         if (sizeof($constraints) > 1 && get_class($constraints[1]) == "FG\ASN1\Universal\Boolean") {
+             if ($constraints[1]->getContent() == "TRUE") {
+                 $this->isCA = true;
+                 $this->pathLength = $constraints[2]->getContent();
+             }
+         } else {
+             $this->isCA = false;
+         }
+         $this->binary = $asn1Extension;
+     }
 
-    }
+     public function getType()
+     {
+         return self::type;
+     }
 
-    public function getType()
-    {
-        return self::type;
-    }
+     public function getURI()
+     {
+         return self::uri;
+     }
 
-    public function getURI()
-    {
-        return self::uri;
-    }
-}
+     public function isCA()
+     {
+         return $this->isCA;
+     }
+
+     public function getPathLength()
+     {
+         if ($this->isCA) {
+             return $this->pathLength;
+         } else {
+             return false;
+         }
+     }
+ }

--- a/src/Certificate/CRLDistributionPoints.php
+++ b/src/Certificate/CRLDistributionPoints.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace eIDASCertificate\Certificate;
+
+use eIDASCertificate\Certificate\ExtensionInterface;
+use eIDASCertificate\Certificate\ExtensionException;
+use eIDASCertificate\OID;
+use FG\ASN1\ASNObject;
+use FG\ASN1\ExplicitlyTaggedObject;
+use FG\ASN1\Universal\PrintableString;
+
+/**
+ *
+ */
+ class CRLDistributionPoints implements ExtensionInterface
+ {
+     private $binary;
+     private $pathLength;
+     private $isCA;
+     const type = 'crlDistributionPoints';
+     const oid = '2.5.29.31';
+     const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.13';
+
+     public function __construct($asn1Extension)
+     {
+         $this->binary = $asn1Extension;
+     }
+
+     public function getType()
+     {
+         return self::type;
+     }
+
+     public function getURI()
+     {
+         return self::uri;
+     }
+
+     public function isCA()
+     {
+         return $this->isCA;
+     }
+
+     public function getPathLength()
+     {
+         if ($this->isCA) {
+             return $this->pathLength;
+         } else {
+             return false;
+         }
+     }
+
+     public function getBinary()
+     {
+         return $this->binary;
+     }
+ }

--- a/src/Certificate/CRLDistributionPoints.php
+++ b/src/Certificate/CRLDistributionPoints.php
@@ -24,7 +24,6 @@ use ASN1\Type\UnspecifiedType;
          $this->cdpEntries = [];
          $this->binary = $asn1Extension;
          $seq = UnspecifiedType::fromDER($asn1Extension)->asSequence();
-         // var_dump($seq);
          foreach ($seq->elements() as $cdpEntry) {
              $cdpEntryDER = $cdpEntry->asSequence()->at(0)->asTagged()->toDER();
              while (bin2hex($cdpEntryDER[0]) == "a0") {

--- a/src/Certificate/ExtendedKeyUsage.php
+++ b/src/Certificate/ExtendedKeyUsage.php
@@ -4,35 +4,61 @@ namespace eIDASCertificate\Certificate;
 
 use eIDASCertificate\Certificate\ExtensionInterface;
 use eIDASCertificate\OID;
-use FG\ASN1\ASNObject;
+use ASN1\Type\UnspecifiedType;
 
 /**
  *
  */
- class ExtendedKeyUsage implements ExtensionInterface
- {
-     private $binary;
-     const type = 'extKeyUsage';
-     const oid = '2.5.29.37';
-     const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.12';
+class ExtendedKeyUsage implements ExtensionInterface
+{
+    private $binary;
+    private $ekus;
+    const type = 'extKeyUsage';
+    const oid = '2.5.29.37';
+    const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.12';
 
-     public function __construct($asn1Extension)
-     {
-         $this->binary = ASNObject::fromBinary($asn1Extension);
-     }
+    public function __construct($asn1Extension)
+    {
+        $this->ekus = [];
+        $ekus = UnspecifiedType::fromDER($asn1Extension)->asSequence();
+        foreach ($ekus->elements() as $eku) {
+            $ekuOID = $eku->asObjectIdentifier()->oid();
+            $ekuName = OID::getName($ekuOID);
+            if ($ekuName == 'unknown') {
+                throw new ExtensionException("Unrecognised EKU $ekuOID", 1);
+            } else {
+                $this->ekus[$ekuName] = true;
+            }
+        }
 
-     public function getType()
-     {
-         return self::type;
-     }
+        $this->binary = $asn1Extension;
+    }
 
-     public function getURI()
-     {
-         return self::uri;
-     }
+    public function getType()
+    {
+        return self::type;
+    }
 
-     public function getBinary()
-     {
-         return $this->binary;
-     }
- }
+    public function getURI()
+    {
+        return self::uri;
+    }
+
+    public function getBinary()
+    {
+        return $this->binary;
+    }
+
+    public function getEKUs()
+    {
+    }
+
+    public function forPurpose($purpose)
+    {
+        if (array_key_exists($purpose, $this->ekus)) {
+            return $this->ekus[$purpose];
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/Certificate/ExtendedKeyUsage.php
+++ b/src/Certificate/ExtendedKeyUsage.php
@@ -30,4 +30,9 @@ use FG\ASN1\ASNObject;
      {
          return self::uri;
      }
+
+     public function getBinary()
+     {
+         return $this->binary;
+     }
  }

--- a/src/Certificate/ExtendedKeyUsage.php
+++ b/src/Certificate/ExtendedKeyUsage.php
@@ -10,24 +10,24 @@ use FG\ASN1\ASNObject;
  *
  */
  class ExtendedKeyUsage implements ExtensionInterface
-{
-    private $binary;
-    const type = 'extKeyUsage';
-    const oid = '2.5.29.37';
-    const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.12';
+ {
+     private $binary;
+     const type = 'extKeyUsage';
+     const oid = '2.5.29.37';
+     const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.12';
 
-    public function __construct($asn1Extension)
-    {
-        $this->binary = ASNObject::fromBinary($asn1Extension);
-    }
+     public function __construct($asn1Extension)
+     {
+         $this->binary = ASNObject::fromBinary($asn1Extension);
+     }
 
-    public function getType()
-    {
-        return self::type;
-    }
+     public function getType()
+     {
+         return self::type;
+     }
 
-    public function getURI()
-    {
-        return self::uri;
-    }
-}
+     public function getURI()
+     {
+         return self::uri;
+     }
+ }

--- a/src/Certificate/ExtendedKeyUsage.php
+++ b/src/Certificate/ExtendedKeyUsage.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace eIDASCertificate\Certificate;
+
+use eIDASCertificate\Certificate\ExtensionInterface;
+use eIDASCertificate\OID;
+use FG\ASN1\ASNObject;
+
+/**
+ *
+ */
+ class ExtendedKeyUsage implements ExtensionInterface
+{
+    private $binary;
+    const type = 'extKeyUsage';
+    const oid = '2.5.29.37';
+    const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.12';
+
+    public function __construct($asn1Extension)
+    {
+        $this->binary = ASNObject::fromBinary($asn1Extension);
+    }
+
+    public function getType()
+    {
+        return self::type;
+    }
+
+    public function getURI()
+    {
+        return self::uri;
+    }
+}

--- a/src/Certificate/Extension.php
+++ b/src/Certificate/Extension.php
@@ -18,6 +18,10 @@ abstract class Extension
         $extensionOid = $extension[0]->getContent();
         $extensionName = OID::getName($extensionOid);
         switch ($extensionName) {
+          case 'preCertPoison':
+            return new PreCertPoison($extension->getbinary());
+            // TODO: Properly handle poisoned certificates
+            break;
           case 'keyUsage':
             return new KeyUsage($extension->getbinary());
             break;
@@ -27,7 +31,7 @@ abstract class Extension
 
           default:
             if ($extension[1]->getContent() === "TRUE") {
-              throw new \Exception("Unrecognised Critical Extension OID '$extensionOid' ($extensionName), cannot proceed", 1);
+              throw new ExtensionException("Unrecognised Critical Extension OID '$extensionOid' ($extensionName), cannot proceed", 1);
             } else {
                 return new UnknownExtension($extension->getbinary());
             }

--- a/src/Certificate/Extension.php
+++ b/src/Certificate/Extension.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace eIDASCertificate\Certificate;
+
+use eIDASCertificate\QCStatements;
+use FG\ASN1\ASNObject;
+
+/**
+ *
+ */
+abstract class Extension
+{
+    public static function fromBinary($binary)
+    {
+        $extension = ASNObject::fromBinary($binary);
+    }
+}

--- a/src/Certificate/Extension.php
+++ b/src/Certificate/Extension.php
@@ -49,7 +49,12 @@ abstract class Extension
 
           default:
             if ($extension[1]->getContent() === "TRUE") {
-                throw new ExtensionException("Unrecognised Critical Extension OID '$extensionOid' ($extensionName), cannot proceed", 1);
+                throw new ExtensionException(
+                    "Unrecognised Critical Extension OID '$extensionOid' ($extensionName), cannot proceed: '" .
+                    base64_encode($extension->getBinary()).
+                    "'",
+                    1
+                );
             } else {
                 return new UnknownExtension($extension->getbinary());
             }

--- a/src/Certificate/Extension.php
+++ b/src/Certificate/Extension.php
@@ -47,6 +47,10 @@ abstract class Extension
             // TODO: Implement EKU
             return new ExtendedKeyUsage($extnValue);
             break;
+          case 'crlDistributionPoints':
+            // TODO: Implement CDPs
+            return new CRLDistributionPoints($extnValue);
+            break;
           case 'qcStatements':
             // TODO: Implemented on certificate object
             return false;

--- a/src/Certificate/Extension.php
+++ b/src/Certificate/Extension.php
@@ -16,32 +16,44 @@ abstract class Extension
     public static function fromASNObject($extension)
     {
         $extensionOid = $extension[0]->getContent();
+        if (get_class($extension[1]) == "FG\ASN1\Universal\Boolean") {
+            $isCritical = ($extension[1]->getContent() === "TRUE");
+            $extnValue = hex2bin($extension[2]->getContent());
+        } else {
+            $isCritical = false;
+            $extnValue = hex2bin($extension[1]->getContent());
+        }
         $extensionName = OID::getName($extensionOid);
+        // print $extensionName . ": " . base64_encode($extnValue) .PHP_EOL;
         switch ($extensionName) {
           case 'basicConstraints':
-            return new BasicConstraints($extension->getbinary());
-            // TODO: Properly Basic Constraints
+            // TODO: Properly handle Basic Constraints
+            return new BasicConstraints($extnValue);
             break;
           case 'preCertPoison':
-            return new PreCertPoison($extension->getbinary());
+            return new PreCertPoison($extnValue);
             // TODO: Properly handle poisoned certificates
             break;
           case 'keyUsage':
-            return new KeyUsage($extension->getbinary());
+            return false; // Canot parse bit strings with current library
+            // return new KeyUsage($extnValue);
             break;
-          // case 'authorityKeyIdentifier':
-          //   return new AuthorityKeyIdentifier($extension->getbinary());
-          //   break;
+          case 'authorityKeyIdentifier':
+            // TODO: Implement AKI
+            return new AuthorityKeyIdentifier($extnValue);
+            break;
+          case 'extKeyUsage':
+            // TODO: Implement EKU
+            return new ExtendedKeyUsage($extnValue);
+            break;
 
           default:
             if ($extension[1]->getContent() === "TRUE") {
-              throw new ExtensionException("Unrecognised Critical Extension OID '$extensionOid' ($extensionName), cannot proceed", 1);
+                throw new ExtensionException("Unrecognised Critical Extension OID '$extensionOid' ($extensionName), cannot proceed", 1);
             } else {
                 return new UnknownExtension($extension->getbinary());
             }
             break;
         }
-        // var_dump([$extension[0]->getContent(), $name]);
-        // return($extention);
     }
 }

--- a/src/Certificate/Extension.php
+++ b/src/Certificate/Extension.php
@@ -2,7 +2,10 @@
 
 namespace eIDASCertificate\Certificate;
 
-use eIDASCertificate\QCStatements;
+use eIDASCertificate\Certificate\ExtensionException;
+use eIDASCertificate\Certificate\AuthorityKeyIdentifier;
+use eIDASCertificate\Certificate\UnknownExtension;
+use eIDASCertificate\OID;
 use FG\ASN1\ASNObject;
 
 /**
@@ -10,8 +13,27 @@ use FG\ASN1\ASNObject;
  */
 abstract class Extension
 {
-    public static function fromBinary($binary)
+    public static function fromASNObject($extension)
     {
-        $extension = ASNObject::fromBinary($binary);
+        $extensionOid = $extension[0]->getContent();
+        $extensionName = OID::getName($extensionOid);
+        switch ($extensionName) {
+          case 'keyUsage':
+            return new KeyUsage($extension->getbinary());
+            break;
+          // case 'authorityKeyIdentifier':
+          //   return new AuthorityKeyIdentifier($extension->getbinary());
+          //   break;
+
+          default:
+            if ($extension[1]->getContent() === "TRUE") {
+              throw new \Exception("Unrecognised Critical Extension OID '$extensionOid' ($extensionName), cannot proceed", 1);
+            } else {
+                return new UnknownExtension($extension->getbinary());
+            }
+            break;
+        }
+        // var_dump([$extension[0]->getContent(), $name]);
+        // return($extention);
     }
 }

--- a/src/Certificate/Extension.php
+++ b/src/Certificate/Extension.php
@@ -18,6 +18,10 @@ abstract class Extension
         $extensionOid = $extension[0]->getContent();
         $extensionName = OID::getName($extensionOid);
         switch ($extensionName) {
+          case 'basicConstraints':
+            return new BasicConstraints($extension->getbinary());
+            // TODO: Properly Basic Constraints
+            break;
           case 'preCertPoison':
             return new PreCertPoison($extension->getbinary());
             // TODO: Properly handle poisoned certificates

--- a/src/Certificate/Extension.php
+++ b/src/Certificate/Extension.php
@@ -24,7 +24,8 @@ abstract class Extension
             $extnValue = hex2bin($extension[1]->getContent());
         }
         $extensionName = OID::getName($extensionOid);
-        // print $extensionName . ": " . base64_encode($extnValue) .PHP_EOL;
+        // print "$extensionOid ($extensionName)" . PHP_EOL;
+        print "$extensionOid ($extensionName): " . base64_encode($extnValue) .PHP_EOL;
         switch ($extensionName) {
           case 'basicConstraints':
             // TODO: Properly handle Basic Constraints
@@ -46,6 +47,10 @@ abstract class Extension
             // TODO: Implement EKU
             return new ExtendedKeyUsage($extnValue);
             break;
+          case 'qcStatements':
+            // TODO: Implemented on certificate object
+            return false;
+            break;
 
           default:
             if ($extension[1]->getContent() === "TRUE") {
@@ -56,6 +61,7 @@ abstract class Extension
                     1
                 );
             } else {
+                // print $extensionName . PHP_EOL;
                 return new UnknownExtension($extension->getbinary());
             }
             break;

--- a/src/Certificate/ExtensionException.php
+++ b/src/Certificate/ExtensionException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eIDASCertificate\QCStatements;
+namespace eIDASCertificate\Certificate;
 
 /**
  *

--- a/src/Certificate/ExtensionException.php
+++ b/src/Certificate/ExtensionException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace eIDASCertificate\QCStatements;
+
+/**
+ *
+ */
+class ExtensionException extends \Exception
+{
+}

--- a/src/Certificate/ExtensionInterface.php
+++ b/src/Certificate/ExtensionInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace eIDASCertificate\Certificate;
+
+/**
+ *
+ */
+ interface ExtensionInterface
+ {
+     public function getType();
+     // public function getDescription();
+     public function getURI();
+     // public function getBinary();
+ }

--- a/src/Certificate/ExtensionInterface.php
+++ b/src/Certificate/ExtensionInterface.php
@@ -10,5 +10,5 @@ namespace eIDASCertificate\Certificate;
      public function getType();
      // public function getDescription();
      public function getURI();
-     // public function getBinary();
+     public function getBinary();
  }

--- a/src/Certificate/Extensions.php
+++ b/src/Certificate/Extensions.php
@@ -21,6 +21,7 @@ use FG\ASN1\ASNObject;
          foreach ($this->asn1Object as $extension) {
              $v3Extension = Extension::fromASNObject($extension);
              if ($v3Extension) {
+                 var_dump(get_class($v3Extension));
                  if ($v3Extension->getType() != 'unknown') {
                      if (array_key_exists($v3Extension->getType(), $this->extensions)) {
                          throw new ExtensionException(
@@ -28,10 +29,10 @@ use FG\ASN1\ASNObject;
                              1
                          );
                      } else {
-                         $this->extensions[$v3Extension->getType()] = $extension;
+                         $this->extensions[$v3Extension->getType()] = $v3Extension;
                      }
                  } else {
-                     $this->extensions[$v3Extension->getType().'-'.$v3Extension->getOID()] = $extension;
+                     $this->extensions[$v3Extension->getType().'-'.$v3Extension->getOID()] = $v3Extension;
                  }
              }
          }

--- a/src/Certificate/Extensions.php
+++ b/src/Certificate/Extensions.php
@@ -21,7 +21,6 @@ use FG\ASN1\ASNObject;
          foreach ($this->asn1Object as $extension) {
              $v3Extension = Extension::fromASNObject($extension);
              if ($v3Extension) {
-                 var_dump(get_class($v3Extension));
                  if ($v3Extension->getType() != 'unknown') {
                      if (array_key_exists($v3Extension->getType(), $this->extensions)) {
                          throw new ExtensionException(

--- a/src/Certificate/Extensions.php
+++ b/src/Certificate/Extensions.php
@@ -21,19 +21,17 @@ use FG\ASN1\ASNObject;
          foreach ($this->asn1Object as $extension) {
              $v3Extension = Extension::fromASNObject($extension);
              if ($v3Extension) {
-                 // code...
                  if ($v3Extension->getType() != 'unknown') {
                      if (array_key_exists($v3Extension->getType(), $this->extensions)) {
                          throw new ExtensionException(
-                    "Multiple Certificate Extensions of type " . $v3Extension->getType(),
-                    1
-                );
+                             "Multiple Certificate Extensions of type " . $v3Extension->getType(),
+                             1
+                         );
                      } else {
                          $this->extensions[$v3Extension->getType()] = $extension;
                      }
                  } else {
                      $this->extensions[$v3Extension->getType().'-'.$v3Extension->getOID()] = $extension;
-                     // code...
                  }
              }
          }

--- a/src/Certificate/Extensions.php
+++ b/src/Certificate/Extensions.php
@@ -11,29 +11,42 @@ use FG\ASN1\ASNObject;
  *
  */
  class Extensions
-{
-    private $extensions = [];
+ {
+     private $extensions = [];
 
-    public function __construct($asn1Extensions)
-    {
-      $this->extensions = [];
-      $this->asn1Object = ASNObject::fromBinary($asn1Extensions);
-      foreach ($this->asn1Object as $extension) {
-          $v3Extension = Extension::fromASNObject($extension);
-          if ($v3Extension->getType() != 'unknown') {
-            if (array_key_exists($v3Extension->getType(), $this->extensions)) {
-              throw new ExtensionException(
-                "Multiple Certificate Extensions of type " . $v3Extension->getType(),
-                1
-              );
-            } else {
-              $this->extensions[$v3Extension->getType()] = $extension;
-            }
-          } else {
-            $this->extensions[$v3Extension->getType().'-'.$v3Extension->getOID()] = $extension;
-            // code...
-          }
-      }
-      // var_dump($this->extensions);
-    }
-}
+     public function __construct($asn1Extensions)
+     {
+         $this->extensions = [];
+         $this->asn1Object = ASNObject::fromBinary($asn1Extensions);
+         foreach ($this->asn1Object as $extension) {
+             $v3Extension = Extension::fromASNObject($extension);
+             if ($v3Extension) {
+                 // code...
+                 if ($v3Extension->getType() != 'unknown') {
+                     if (array_key_exists($v3Extension->getType(), $this->extensions)) {
+                         throw new ExtensionException(
+                    "Multiple Certificate Extensions of type " . $v3Extension->getType(),
+                    1
+                );
+                     } else {
+                         $this->extensions[$v3Extension->getType()] = $extension;
+                     }
+                 } else {
+                     $this->extensions[$v3Extension->getType().'-'.$v3Extension->getOID()] = $extension;
+                     // code...
+                 }
+             }
+         }
+         // TODO: Minimum set https://tools.ietf.org/html/rfc5280#section-4.2
+     }
+
+     public function setKeyUsage($keyUsageString)
+     {
+         $this->extensions['keyUsage'] = new KeyUsage($keyUsageString);
+     }
+
+     public function getExtensions()
+     {
+         return $this->extensions;
+     }
+ }

--- a/src/Certificate/Extensions.php
+++ b/src/Certificate/Extensions.php
@@ -34,6 +34,6 @@ use FG\ASN1\ASNObject;
             // code...
           }
       }
-      var_dump($this->extensions);
+      // var_dump($this->extensions);
     }
 }

--- a/src/Certificate/Extensions.php
+++ b/src/Certificate/Extensions.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace eIDASCertificate\Certificate;
+
+use eIDASCertificate\Certificate;
+use eIDASCertificate\Certificate\ExtensionException;
+use eIDASCertificate\OID;
+use FG\ASN1\ASNObject;
+
+/**
+ *
+ */
+ class Extensions
+{
+    private $extensions = [];
+
+    public function __construct($asn1Extensions)
+    {
+      $this->extensions = [];
+      $this->asn1Object = ASNObject::fromBinary($asn1Extensions);
+      foreach ($this->asn1Object as $extension) {
+          $v3Extension = Extension::fromASNObject($extension);
+          if ($v3Extension->getType() != 'unknown') {
+            if (array_key_exists($v3Extension->getType(), $this->extensions)) {
+              throw new ExtensionException(
+                "Multiple Certificate Extensions of type " . $v3Extension->getType(),
+                1
+              );
+            } else {
+              $this->extensions[$v3Extension->getType()] = $extension;
+            }
+          } else {
+            $this->extensions[$v3Extension->getType().'-'.$v3Extension->getOID()] = $extension;
+            // code...
+          }
+      }
+      var_dump($this->extensions);
+    }
+}

--- a/src/Certificate/KeyUsage.php
+++ b/src/Certificate/KeyUsage.php
@@ -29,4 +29,9 @@ use FG\ASN1\ASNObject;
      {
          return self::uri;
      }
+
+     public function getBinary()
+     {
+         return false; // Unable to use binary, so deriving this from parsed
+     }
  }

--- a/src/Certificate/KeyUsage.php
+++ b/src/Certificate/KeyUsage.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace eIDASCertificate\Certificate;
+
+use eIDASCertificate\Certificate\ExtensionInterface;
+use eIDASCertificate\OID;
+use FG\ASN1\ASNObject;
+
+/**
+ *
+ */
+ class KeyUsage implements ExtensionInterface
+{
+    private $binary;
+    const type = 'keyUsage';
+    const oid = '2.5.29.15';
+    const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.3';
+
+    public function __construct($asn1Extension)
+    {
+
+    }
+
+    public function getType()
+    {
+        return self::type;
+    }
+
+    public function getURI()
+    {
+        return self::uri;
+    }
+}

--- a/src/Certificate/KeyUsage.php
+++ b/src/Certificate/KeyUsage.php
@@ -10,24 +10,23 @@ use FG\ASN1\ASNObject;
  *
  */
  class KeyUsage implements ExtensionInterface
-{
-    private $binary;
-    const type = 'keyUsage';
-    const oid = '2.5.29.15';
-    const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.3';
+ {
+     const type = 'keyUsage';
+     const oid = '2.5.29.15';
+     const uri = 'https://tools.ietf.org/html/rfc5280#section-4.2.1.3';
 
-    public function __construct($asn1Extension)
-    {
+     public function __construct($keyUsageString)
+     {
+         $this->keyUsage = explode(", ", $keyUsageString);
+     }
 
-    }
+     public function getType()
+     {
+         return self::type;
+     }
 
-    public function getType()
-    {
-        return self::type;
-    }
-
-    public function getURI()
-    {
-        return self::uri;
-    }
-}
+     public function getURI()
+     {
+         return self::uri;
+     }
+ }

--- a/src/Certificate/PreCertPoison.php
+++ b/src/Certificate/PreCertPoison.php
@@ -10,24 +10,24 @@ use FG\ASN1\ASNObject;
  *
  */
  class PreCertPoison implements ExtensionInterface
-{
-    private $binary;
-    const type = 'preCertPoison';
-    const oid = '1.3.6.1.4.1.11129.2.4.3';
-    const uri = 'https://tools.ietf.org/html/rfc6962#section-3.1';
+ {
+     private $binary;
+     const type = 'preCertPoison';
+     const oid = '1.3.6.1.4.1.11129.2.4.3';
+     const uri = 'https://tools.ietf.org/html/rfc6962#section-3.1';
 
-    public function __construct($asn1Extension)
-    {
-        $this->binary = ASNObject::fromBinary($asn1Extension);
-    }
+     public function __construct($asn1Extension)
+     {
+         $this->binary = ASNObject::fromBinary($asn1Extension);
+     }
 
-    public function getType()
-    {
-        return self::type;
-    }
+     public function getType()
+     {
+         return self::type;
+     }
 
-    public function getURI()
-    {
-        return self::uri;
-    }
-}
+     public function getURI()
+     {
+         return self::uri;
+     }
+ }

--- a/src/Certificate/PreCertPoison.php
+++ b/src/Certificate/PreCertPoison.php
@@ -35,5 +35,4 @@ use FG\ASN1\ASNObject;
      {
          return $this->binary;
      }
-
  }

--- a/src/Certificate/PreCertPoison.php
+++ b/src/Certificate/PreCertPoison.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace eIDASCertificate\Certificate;
+
+use eIDASCertificate\Certificate\ExtensionInterface;
+use eIDASCertificate\OID;
+use FG\ASN1\ASNObject;
+
+/**
+ *
+ */
+ class PreCertPoison implements ExtensionInterface
+{
+    private $binary;
+    const type = 'preCertPoison';
+    const oid = '1.3.6.1.4.1.11129.2.4.3';
+    const uri = 'https://tools.ietf.org/html/rfc6962#section-3.1';
+
+    public function __construct($asn1Extension)
+    {
+        $this->binary = ASNObject::fromBinary($asn1Extension);
+    }
+
+    public function getType()
+    {
+        return self::type;
+    }
+
+    public function getURI()
+    {
+        return self::uri;
+    }
+}

--- a/src/Certificate/PreCertPoison.php
+++ b/src/Certificate/PreCertPoison.php
@@ -30,4 +30,10 @@ use FG\ASN1\ASNObject;
      {
          return self::uri;
      }
+
+     public function getBinary()
+     {
+         return $this->binary;
+     }
+
  }

--- a/src/Certificate/UnknownExtension.php
+++ b/src/Certificate/UnknownExtension.php
@@ -10,31 +10,30 @@ use FG\ASN1\ASNObject;
  *
  */
  class UnknownExtension implements ExtensionInterface
-{
-    private $binary;
-    const type = 'unknown';
-    const uri = '';
+ {
+     private $binary;
+     const type = 'unknown';
+     const uri = '';
 
-    public function __construct($binary)
-    {
-      $object = ASNObject::fromBinary($binary);
-      $this->binary = $binary;
-      $this->oid = $object[0]->getContent();
+     public function __construct($binary)
+     {
+         $object = ASNObject::fromBinary($binary);
+         $this->binary = $binary;
+         $this->oid = $object[0]->getContent();
+     }
 
-    }
+     public function getType()
+     {
+         return self::type;
+     }
 
-    public function getType()
-    {
-        return self::type;
-    }
+     public function getURI()
+     {
+         return self::uri;
+     }
 
-    public function getURI()
-    {
-        return self::uri;
-    }
-
-    public function getOID()
-    {
-        return $this->oid;
-    }
-}
+     public function getOID()
+     {
+         return $this->oid;
+     }
+ }

--- a/src/Certificate/UnknownExtension.php
+++ b/src/Certificate/UnknownExtension.php
@@ -36,4 +36,9 @@ use FG\ASN1\ASNObject;
      {
          return $this->oid;
      }
+
+     public function getBinary()
+     {
+         return $this->binary;
+     }
  }

--- a/src/Certificate/UnknownExtension.php
+++ b/src/Certificate/UnknownExtension.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace eIDASCertificate\Certificate;
+
+use eIDASCertificate\Certificate\ExtensionInterface;
+use eIDASCertificate\OID;
+use FG\ASN1\ASNObject;
+
+/**
+ *
+ */
+ class UnknownExtension implements ExtensionInterface
+{
+    private $binary;
+    const type = 'unknown';
+    const uri = '';
+
+    public function __construct($binary)
+    {
+      $object = ASNObject::fromBinary($binary);
+      $this->binary = $binary;
+      $this->oid = $object[0]->getContent();
+
+    }
+
+    public function getType()
+    {
+        return self::type;
+    }
+
+    public function getURI()
+    {
+        return self::uri;
+    }
+
+    public function getOID()
+    {
+        return $this->oid;
+    }
+}

--- a/src/Certificate/X509Certificate.php
+++ b/src/Certificate/X509Certificate.php
@@ -96,4 +96,14 @@ class X509Certificate
             return $this->qcStatements;
         }
     }
+
+    public function toDER()
+    {
+      openssl_x509_export($this->crtResource,$crtPEM);
+      $crtPEM = explode("\n",$crtPEM);
+      unset($crtPEM[sizeof($crtPEM)-1]);
+      unset($crtPEM[0]);
+      $crtDER = base64_decode(implode("",$crtPEM));
+      return $crtDER;
+    }
 }

--- a/src/Certificate/X509Certificate.php
+++ b/src/Certificate/X509Certificate.php
@@ -175,4 +175,11 @@ class X509Certificate
     {
         return $this->extensions;
     }
+
+    public function getCDPs()
+    {
+        if (array_key_exists('crlDistributionPoints', $this->extensions)) {
+            return $this->extensions['crlDistributionPoints']->getCDPs();
+        }
+    }
 }

--- a/src/Certificate/X509Certificate.php
+++ b/src/Certificate/X509Certificate.php
@@ -81,6 +81,51 @@ class X509Certificate
         return $this->parsed;
     }
 
+    public function getDates()
+    {
+        if (empty($this->parsed)) {
+            $this->parsed = X509Certificate::parse($this->crtResource);
+        }
+        return [
+          'notBefore' => date_create( '@' .  $this->parsed['validFrom_time_t']),
+          'notAfter' => date_create( '@' .  $this->parsed['validTo_time_t'])
+        ];
+    }
+
+    public function isValidAt($dateTime = null)
+    {
+      if(empty($dateTime)) {
+        $dateTime = new \DateTime; // now
+      };
+      $dates = $this->getDates();
+      return (
+        $this->isStartedAt($dateTime) &&
+        $this->isNotFinishedAt($dateTime)
+      );
+    }
+
+    public function isStartedAt($dateTime = null)
+    {
+      if(empty($dateTime)) {
+        $dateTime = new \DateTime; // now
+      };
+      $dates = $this->getDates();
+      return (
+        $dates['notBefore'] < $dateTime
+      );
+    }
+
+    public function isNotFinishedAt($dateTime = null)
+    {
+      if(empty($dateTime)) {
+        $dateTime = new \DateTime; // now
+      };
+      $dates = $this->getDates();
+      return (
+        $dates['notAfter'] > $dateTime
+      );
+    }
+
     public function hasExtensions()
     {
         return array_key_exists('extensions', $this->getParsed());

--- a/src/OID.php
+++ b/src/OID.php
@@ -23,6 +23,8 @@ class OID
     const PSP_AI  = '0.4.0.19495.1.3';
     const PSP_IC  = '0.4.0.19495.1.4';
     const PSD2  = '0.4.0.19495.2';
+    const KeyUsage = '2.5.29.15';
+    const AuthorityKeyIdentifier = '2.5.29.35';
 
     public static function getName($oidString)
     {
@@ -78,6 +80,12 @@ class OID
             break;
           case self::PSD2:
             $oidName = 'PSD2';
+            break;
+          case self::KeyUsage:
+            $oidName = 'keyUsage';
+            break;
+          case self::AuthorityKeyIdentifier:
+            $oidName = 'authorityKeyIdentifier';
             break;
           }
         return $oidName;

--- a/src/OID.php
+++ b/src/OID.php
@@ -30,7 +30,8 @@ class OID
     const ExtendedKeyUsage = '2.5.29.37';
     const SubjectKeyIdentifier = '2.5.29.14';
     const AuthorityKeyIdentifier = '2.5.29.35';
-
+    const CRLDistributionPoints = '2.5.29.31';
+    
     public static function getName($oidString)
     {
         // return 'blah';
@@ -39,7 +40,6 @@ class OID
         $oidName = "unknown";
         switch ($oidString) {
           case self::qcStatements:
-
               $oidName = 'qcStatements';
               break;
           case self::PKIX_QCSYNTAX_V2:
@@ -98,6 +98,9 @@ class OID
             break;
           case self::ExtendedKeyUsage:
             $oidName = 'extKeyUsage';
+            break;
+          case self::CRLDistributionPoints:
+            $oidName = 'crlDistributionPoints';
             break;
           case self::PreCertPoison:
             $oidName = 'preCertPoison';

--- a/src/OID.php
+++ b/src/OID.php
@@ -23,6 +23,7 @@ class OID
     const PSP_AI  = '0.4.0.19495.1.3';
     const PSP_IC  = '0.4.0.19495.1.4';
     const PSD2  = '0.4.0.19495.2';
+    const PreCertPoison = '1.3.6.1.4.1.11129.2.4.3';
     const KeyUsage = '2.5.29.15';
     const AuthorityKeyIdentifier = '2.5.29.35';
 
@@ -83,6 +84,9 @@ class OID
             break;
           case self::KeyUsage:
             $oidName = 'keyUsage';
+            break;
+          case self::PreCertPoison:
+            $oidName = 'preCertPoison';
             break;
           case self::AuthorityKeyIdentifier:
             $oidName = 'authorityKeyIdentifier';

--- a/src/OID.php
+++ b/src/OID.php
@@ -26,6 +26,7 @@ class OID
     const PreCertPoison = '1.3.6.1.4.1.11129.2.4.3';
     const BasicConstraints = '2.5.29.19';
     const KeyUsage = '2.5.29.15';
+    const ExtendedKeyUsage = '2.5.29.37';
     const AuthorityKeyIdentifier = '2.5.29.35';
 
     public static function getName($oidString)
@@ -88,6 +89,9 @@ class OID
             break;
           case self::KeyUsage:
             $oidName = 'keyUsage';
+            break;
+          case self::ExtendedKeyUsage:
+            $oidName = 'extKeyUsage';
             break;
           case self::PreCertPoison:
             $oidName = 'preCertPoison';

--- a/src/OID.php
+++ b/src/OID.php
@@ -7,6 +7,7 @@ namespace eIDASCertificate;
  */
 class OID
 {
+    const qcStatements = '1.3.6.1.5.5.7.1.3';
     const PKIX_QCSYNTAX_V2                    = '1.3.6.1.5.5.7.11.2';
     const qcs_QcCompliance                    = '0.4.0.1862.1.1';
     const QcLimitValue  = '0.4.0.1862.1.2';
@@ -27,6 +28,7 @@ class OID
     const BasicConstraints = '2.5.29.19';
     const KeyUsage = '2.5.29.15';
     const ExtendedKeyUsage = '2.5.29.37';
+    const SubjectKeyIdentifier = '2.5.29.14';
     const AuthorityKeyIdentifier = '2.5.29.35';
 
     public static function getName($oidString)
@@ -36,6 +38,10 @@ class OID
 
         $oidName = "unknown";
         switch ($oidString) {
+          case self::qcStatements:
+
+              $oidName = 'qcStatements';
+              break;
           case self::PKIX_QCSYNTAX_V2:
               $oidName = 'id-qcs-pkixQCSyntax-v2';
               break;
@@ -98,6 +104,9 @@ class OID
             break;
           case self::AuthorityKeyIdentifier:
             $oidName = 'authorityKeyIdentifier';
+            break;
+          case self::SubjectKeyIdentifier:
+            $oidName = 'subjectKeyIdentifier';
             break;
           }
         return $oidName;

--- a/src/OID.php
+++ b/src/OID.php
@@ -24,6 +24,7 @@ class OID
     const PSP_IC  = '0.4.0.19495.1.4';
     const PSD2  = '0.4.0.19495.2';
     const PreCertPoison = '1.3.6.1.4.1.11129.2.4.3';
+    const BasicConstraints = '2.5.29.19';
     const KeyUsage = '2.5.29.15';
     const AuthorityKeyIdentifier = '2.5.29.35';
 
@@ -81,6 +82,9 @@ class OID
             break;
           case self::PSD2:
             $oidName = 'PSD2';
+            break;
+          case self::BasicConstraints:
+            $oidName = 'basicConstraints';
             break;
           case self::KeyUsage:
             $oidName = 'keyUsage';

--- a/src/OID.php
+++ b/src/OID.php
@@ -31,7 +31,17 @@ class OID
     const SubjectKeyIdentifier = '2.5.29.14';
     const AuthorityKeyIdentifier = '2.5.29.35';
     const CRLDistributionPoints = '2.5.29.31';
-    
+    const ServerAuth = '1.3.6.1.5.5.7.3.1';
+    const ClientAuth = '1.3.6.1.5.5.7.3.2';
+    const CodeSigning = '1.3.6.1.5.5.7.3.3';
+    const EmailProtection = '1.3.6.1.5.5.7.3.4';
+    const TimeStamping = '1.3.6.1.5.5.7.3.8';
+    const OCSPSigning = '1.3.6.1.5.5.7.3.9';
+    const TSLSigning = '0.4.0.2231.3.0';
+    // https://www.etsi.org/deliver/etsi_ts/102200_102299/102231/03.01.02_60/ts_102231v030102p.pdf$chapter-6.2
+    const MS_DOCUMENT_SIGNING = '1.3.6.1.4.1.311.10.3.12';
+    // https://support.microsoft.com/en-us/help/287547/object-ids-associated-with-microsoft-cryptography
+
     public static function getName($oidString)
     {
         // return 'blah';
@@ -110,6 +120,30 @@ class OID
             break;
           case self::SubjectKeyIdentifier:
             $oidName = 'subjectKeyIdentifier';
+            break;
+          case self::ServerAuth:
+            $oidName = 'serverAuth';
+            break;
+          case self::ClientAuth:
+            $oidName = 'clientAuth';
+            break;
+          case self::CodeSigning:
+            $oidName = 'codeSigning';
+            break;
+          case self::EmailProtection:
+            $oidName = 'emailProtection';
+            break;
+          case self::TimeStamping:
+            $oidName = 'timeStamping';
+            break;
+          case self::OCSPSigning:
+            $oidName = 'OCSPSigning';
+            break;
+          case self::TSLSigning:
+            $oidName = 'tslSigning';
+            break;
+          case self::MS_DOCUMENT_SIGNING:
+            $oidName = 'MS_DOCUMENT_SIGNING';
             break;
           }
         return $oidName;

--- a/src/QCStatements/QCPSD2.php
+++ b/src/QCStatements/QCPSD2.php
@@ -36,7 +36,12 @@ class QCPSD2 extends QCStatement implements QCStatementInterface
         $rolesStatement = $psd2Statement[0];
         foreach ($rolesStatement as $role) {
             if (get_class($role) != "FG\ASN1\Universal\Sequence") {
-                throw new QCStatementException("PSD2 Roles not encoded as a Sequence", 1);
+                throw new QCStatementException(
+                    "PSD2 Roles not encoded as a Sequence: '" .
+                    base64_encode($statements->getBinary()).
+                    "'",
+                    1
+                );
             }
             $psd2Role = OID::getName($role[0]->getContent());
             if ($psd2Role == 'unkown') {
@@ -49,7 +54,11 @@ class QCPSD2 extends QCStatement implements QCStatementInterface
               case 'PSP_IC':
                 if ($psd2Role != $role[1]->getContent()) {
                     throw new QCStatementException(
-                        "PSD2 Named Role '".$role[1]->getContent()."' does not match OID Name '$psd2Role'",
+                        "PSD2 Named Role '".
+                            $role[1]->getContent().
+                            "' does not match OID Name '$psd2Role': '" .
+                            base64_encode($psd2Statement->getBinary()) .
+                        "'",
                         1
                     );
                 }

--- a/src/QCStatements/QCStatement.php
+++ b/src/QCStatements/QCStatement.php
@@ -43,7 +43,12 @@ abstract class QCStatement
           return new QCPSD2($statements);
           break;
         default:
-          throw new QCStatementException("Unrecognised QCStatement OID $qcStatementOID ($qcStatementName)", 1);
+          throw new QCStatementException(
+              "Unrecognised QCStatement OID $qcStatementOID ($qcStatementName): '".
+              base64_encode($statements->getBinary()) .
+               "'",
+              1
+          );
           break;
       }
     }

--- a/src/TrustedList.php
+++ b/src/TrustedList.php
@@ -330,13 +330,21 @@ class TrustedList
     public function getListIssueDateTime()
     {
         if (! $this->listIssueDateTime) {
-            $this->listIssueDateTime = strtotime(
+            $this->listIssueDateTime = new \DateTime(
                 (string)$this->tl->xpath(
                     './tsl:SchemeInformation/tsl:ListIssueDateTime'
                 )[0]
             );
         };
         return $this->listIssueDateTime;
+    }
+
+    public function getListIssueElapsedSeconds()
+    {
+        return (
+          (new \DateTime('now'))->getTimestamp() -
+          $this->getListIssueDateTime()->getTimestamp()
+        );
     }
 
     public function getNextUpdate()
@@ -380,12 +388,18 @@ class TrustedList
      * [getTrustedLists description]
      * @return TrustedList[] [description]
      */
-    public function getTrustedLists()
+    public function getTrustedLists($title = null)
     {
         if (sizeof($this->trustedLists) == 0) {
             $this->processTrustedLists();
         }
-        return $this->trustedLists;
+        if (empty($title)) {
+            return $this->trustedLists;
+        } elseif (array_key_exists($title, $this->trustedLists)) {
+            return $this->trustedLists[$title];
+        } else {
+            return false;
+        }
     }
 
     public function getTrustedListPointers($fileType = null)

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace eIDASCertificate\tests;
+
+use PHPUnit\Framework\TestCase;
+use eIDASCertificate\Certificate\Extension;
+use FG\ASN1\ASNObject;
+
+class ExtensionTest extends TestCase
+{
+    // public function setUp()
+    // {
+    //     $this->datadir = __DIR__ . '/../data';
+    //     $xmlFilePath = $this->datadir.self::lotlXMLFileName;
+    //     if (! file_exists($xmlFilePath)) {
+    //         $this->lotlXML = DataSource::getHTTP(
+    //             TrustedList::ListOfTrustedListsXMLPath
+    //         );
+    //         file_put_contents($xmlFilePath, $this->lotlXML);
+    //     } else {
+    //         $this->lotlXML = file_get_contents($xmlFilePath);
+    //     }
+    // }
+
+    public function testBasicConstraints()
+    {
+        $this->assertTrue(true);
+        // $binary = base64_decode('MFgwJwYIKwYBBQUHMAGGG2h0dHA6Ly9xY2Eub2NzcC5sdXh0cnVzdC5sdTAtBggrBgEFBQcwAoYhaHR0cDovL2NhLmx1eHRydXN0Lmx1L0xUR1FDQTMuY3J0');
+        // $asn1 = ASNObject::fromBinary($binary);
+        // $bc = Extension::fromASNObject($asn1);
+        // $this->assertEquals([
+        //   'abc',
+        //   get_class($ext)
+        // ]);
+    }
+}

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -4,6 +4,7 @@ namespace eIDASCertificate\tests;
 
 use PHPUnit\Framework\TestCase;
 use eIDASCertificate\Certificate\Extension;
+use eIDASCertificate\Certificate\CRLDistributionPoints;
 use FG\ASN1\ASNObject;
 
 class ExtensionTest extends TestCase
@@ -22,15 +23,18 @@ class ExtensionTest extends TestCase
     //     }
     // }
 
-    public function testBasicConstraints()
+    public function testCRLDistributionPoints()
     {
         $this->assertTrue(true);
-        // $binary = base64_decode('MFgwJwYIKwYBBQUHMAGGG2h0dHA6Ly9xY2Eub2NzcC5sdXh0cnVzdC5sdTAtBggrBgEFBQcwAoYhaHR0cDovL2NhLmx1eHRydXN0Lmx1L0xUR1FDQTMuY3J0');
-        // $asn1 = ASNObject::fromBinary($binary);
-        // $bc = Extension::fromASNObject($asn1);
-        // $this->assertEquals([
-        //   'abc',
-        //   get_class($ext)
-        // ]);
+        $binary = base64_decode('MIGrMDegNaAzhjFodHRwOi8vcXRsc2NhMjAxOC1jcmwxLmUtc3ppZ25vLmh1L3F0bHNjYTIwMTguY3JsMDegNaAzhjFodHRwOi8vcXRsc2NhMjAxOC1jcmwyLmUtc3ppZ25vLmh1L3F0bHNjYTIwMTguY3JsMDegNaAzhjFodHRwOi8vcXRsc2NhMjAxOC1jcmwzLmUtc3ppZ25vLmh1L3F0bHNjYTIwMTguY3Js');
+        $extnCDPs = new CRLDistributionPoints($binary);
+        $this->assertEquals(
+            $extnCDPs->getCDPs(),
+            [
+            'http://qtlsca2018-crl1.e-szigno.hu/qtlsca2018.crl',
+            'http://qtlsca2018-crl2.e-szigno.hu/qtlsca2018.crl',
+            'http://qtlsca2018-crl3.e-szigno.hu/qtlsca2018.crl'
+          ]
+        );
     }
 }

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -4,6 +4,7 @@ namespace eIDASCertificate\tests;
 
 use PHPUnit\Framework\TestCase;
 use eIDASCertificate\Certificate\Extension;
+use eIDASCertificate\Certificate\Extensions;
 use eIDASCertificate\Certificate\CRLDistributionPoints;
 use FG\ASN1\ASNObject;
 
@@ -25,6 +26,21 @@ class ExtensionTest extends TestCase
 
     public function testExtensions()
     {
+        $extensionsDER = base64_decode("MIIFFDAOBgNVHQ8BAf8EBAMCBaAwEwYKKwYBBAHWeQIEAwEB/wQCBQAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMIIBXQYDVR0gBIIBVDCCAVAwggE3Bg8rBgEEAYGoGAIBAYEqAgkwggEiMCYGCCsGAQUFBwIBFhpodHRwOi8vY3AuZS1zemlnbm8uaHUvcWNwczBEBggrBgEFBQcCAjA4DDZRdWFsaWZpZWQgUFNEMiBjZXJ0aWZpY2F0ZSBmb3Igd2Vic2l0ZSBhdXRoZW50aWNhdGlvbi4wNAYIKwYBBQUHAgIwKAwmT3JnYW5pemF0aW9uYWwgdmFsaWRhdGlvbiBjZXJ0aWZpY2F0ZS4wRQYIKwYBBQUHAgIwOQw3TWluxZFzw610ZXR0IFBTRDIgd2Vib2xkYWwtaGl0ZWxlc8OtdMWRIHRhbsO6c8OtdHbDoW55LjA1BggrBgEFBQcCAjApDCdTemVydmV6ZXQtZWxsZW7FkXJ6w7Z0dCB0YW7DunPDrXR2w6FueS4wCQYHBACBmCcDATAIBgZngQwBAgIwHQYDVR0OBBYEFCI7XaCk9Uctd6iTKpvkp0m19TRqMB8GA1UdIwQYMBaAFH2ETsLUa+rB1yKMaMPpoPTsmIocMCgGA1UdEQQhMB+CHXBzZDJodWIucXdhYy5jbGllbnQuYXBpLmtoLmh1MIG2BgNVHR8Ega4wgaswN6A1oDOGMWh0dHA6Ly9xdGxzY2EyMDE4LWNybDEuZS1zemlnbm8uaHUvcXRsc2NhMjAxOC5jcmwwN6A1oDOGMWh0dHA6Ly9xdGxzY2EyMDE4LWNybDIuZS1zemlnbm8uaHUvcXRsc2NhMjAxOC5jcmwwN6A1oDOGMWh0dHA6Ly9xdGxzY2EyMDE4LWNybDMuZS1zemlnbm8uaHUvcXRsc2NhMjAxOC5jcmwwggFfBggrBgEFBQcBAQSCAVEwggFNMC8GCCsGAQUFBzABhiNodHRwOi8vcXRsc2NhMjAxOC1vY3NwMS5lLXN6aWduby5odTAvBggrBgEFBQcwAYYjaHR0cDovL3F0bHNjYTIwMTgtb2NzcDIuZS1zemlnbm8uaHUwLwYIKwYBBQUHMAGGI2h0dHA6Ly9xdGxzY2EyMDE4LW9jc3AzLmUtc3ppZ25vLmh1MDwGCCsGAQUFBzAChjBodHRwOi8vcXRsc2NhMjAxOC1jYTEuZS1zemlnbm8uaHUvcXRsc2NhMjAxOC5jcnQwPAYIKwYBBQUHMAKGMGh0dHA6Ly9xdGxzY2EyMDE4LWNhMi5lLXN6aWduby5odS9xdGxzY2EyMDE4LmNydDA8BggrBgEFBQcwAoYwaHR0cDovL3F0bHNjYTIwMTgtY2EzLmUtc3ppZ25vLmh1L3F0bHNjYTIwMTguY3J0MIHmBggrBgEFBQcBAwSB2TCB1jAIBgYEAI5GAQEwCwYGBACORgEDAgEKMFMGBgQAjkYBBTBJMCQWHmh0dHBzOi8vY3AuZS1zemlnbm8uaHUvcWNwc19lbhMCRU4wIRYbaHR0cHM6Ly9jcC5lLXN6aWduby5odS9xY3BzEwJIVTATBgYEAI5GAQYwCQYHBACORgEGAzBTBgYEAIGYJwIwSTAmMBEGBwQAgZgnAQIMBlBTUF9QSTARBgcEAIGYJwEDDAZQU1BfQUkMF0NlbnRyYWwgQmFuayBvZiBIdW5nYXJ5DAZIVS1DQkg=");
+        $extensions = new Extensions($extensionsDER);
+        $this->assertEquals(
+            [
+            'preCertPoison',
+            'extKeyUsage',
+            'unknown-2.5.29.32',
+            'unknown-2.5.29.14',
+            'authorityKeyIdentifier',
+            'unknown-2.5.29.17',
+            'crlDistributionPoints',
+            'unknown-1.3.6.1.5.5.7.1.1'
+          ],
+            array_keys($extensions->getExtensions())
+        );
         // TODO: Throw a full Extensions block at Extensions class and test result has right entries
     }
 

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -23,6 +23,11 @@ class ExtensionTest extends TestCase
     //     }
     // }
 
+    public function testExtensions()
+    {
+        // TODO: Throw a full Extensions block at Extensions class and test result has right entries
+    }
+
     public function testCRLDistributionPoints()
     {
         $this->assertTrue(true);

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -6,27 +6,40 @@ use PHPUnit\Framework\TestCase;
 use eIDASCertificate\Certificate\Extension;
 use eIDASCertificate\Certificate\Extensions;
 use eIDASCertificate\Certificate\CRLDistributionPoints;
-use FG\ASN1\ASNObject;
+use eIDASCertificate\Certificate\ExtendedKeyUsage;
 
 class ExtensionTest extends TestCase
 {
-    // public function setUp()
-    // {
-    //     $this->datadir = __DIR__ . '/../data';
-    //     $xmlFilePath = $this->datadir.self::lotlXMLFileName;
-    //     if (! file_exists($xmlFilePath)) {
-    //         $this->lotlXML = DataSource::getHTTP(
-    //             TrustedList::ListOfTrustedListsXMLPath
-    //         );
-    //         file_put_contents($xmlFilePath, $this->lotlXML);
-    //     } else {
-    //         $this->lotlXML = file_get_contents($xmlFilePath);
-    //     }
-    // }
-
     public function testExtensions()
     {
-        $extensionsDER = base64_decode("MIIFFDAOBgNVHQ8BAf8EBAMCBaAwEwYKKwYBBAHWeQIEAwEB/wQCBQAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMIIBXQYDVR0gBIIBVDCCAVAwggE3Bg8rBgEEAYGoGAIBAYEqAgkwggEiMCYGCCsGAQUFBwIBFhpodHRwOi8vY3AuZS1zemlnbm8uaHUvcWNwczBEBggrBgEFBQcCAjA4DDZRdWFsaWZpZWQgUFNEMiBjZXJ0aWZpY2F0ZSBmb3Igd2Vic2l0ZSBhdXRoZW50aWNhdGlvbi4wNAYIKwYBBQUHAgIwKAwmT3JnYW5pemF0aW9uYWwgdmFsaWRhdGlvbiBjZXJ0aWZpY2F0ZS4wRQYIKwYBBQUHAgIwOQw3TWluxZFzw610ZXR0IFBTRDIgd2Vib2xkYWwtaGl0ZWxlc8OtdMWRIHRhbsO6c8OtdHbDoW55LjA1BggrBgEFBQcCAjApDCdTemVydmV6ZXQtZWxsZW7FkXJ6w7Z0dCB0YW7DunPDrXR2w6FueS4wCQYHBACBmCcDATAIBgZngQwBAgIwHQYDVR0OBBYEFCI7XaCk9Uctd6iTKpvkp0m19TRqMB8GA1UdIwQYMBaAFH2ETsLUa+rB1yKMaMPpoPTsmIocMCgGA1UdEQQhMB+CHXBzZDJodWIucXdhYy5jbGllbnQuYXBpLmtoLmh1MIG2BgNVHR8Ega4wgaswN6A1oDOGMWh0dHA6Ly9xdGxzY2EyMDE4LWNybDEuZS1zemlnbm8uaHUvcXRsc2NhMjAxOC5jcmwwN6A1oDOGMWh0dHA6Ly9xdGxzY2EyMDE4LWNybDIuZS1zemlnbm8uaHUvcXRsc2NhMjAxOC5jcmwwN6A1oDOGMWh0dHA6Ly9xdGxzY2EyMDE4LWNybDMuZS1zemlnbm8uaHUvcXRsc2NhMjAxOC5jcmwwggFfBggrBgEFBQcBAQSCAVEwggFNMC8GCCsGAQUFBzABhiNodHRwOi8vcXRsc2NhMjAxOC1vY3NwMS5lLXN6aWduby5odTAvBggrBgEFBQcwAYYjaHR0cDovL3F0bHNjYTIwMTgtb2NzcDIuZS1zemlnbm8uaHUwLwYIKwYBBQUHMAGGI2h0dHA6Ly9xdGxzY2EyMDE4LW9jc3AzLmUtc3ppZ25vLmh1MDwGCCsGAQUFBzAChjBodHRwOi8vcXRsc2NhMjAxOC1jYTEuZS1zemlnbm8uaHUvcXRsc2NhMjAxOC5jcnQwPAYIKwYBBQUHMAKGMGh0dHA6Ly9xdGxzY2EyMDE4LWNhMi5lLXN6aWduby5odS9xdGxzY2EyMDE4LmNydDA8BggrBgEFBQcwAoYwaHR0cDovL3F0bHNjYTIwMTgtY2EzLmUtc3ppZ25vLmh1L3F0bHNjYTIwMTguY3J0MIHmBggrBgEFBQcBAwSB2TCB1jAIBgYEAI5GAQEwCwYGBACORgEDAgEKMFMGBgQAjkYBBTBJMCQWHmh0dHBzOi8vY3AuZS1zemlnbm8uaHUvcWNwc19lbhMCRU4wIRYbaHR0cHM6Ly9jcC5lLXN6aWduby5odS9xY3BzEwJIVTATBgYEAI5GAQYwCQYHBACORgEGAzBTBgYEAIGYJwIwSTAmMBEGBwQAgZgnAQIMBlBTUF9QSTARBgcEAIGYJwEDDAZQU1BfQUkMF0NlbnRyYWwgQmFuayBvZiBIdW5nYXJ5DAZIVS1DQkg=");
+        $extensionsDER = base64_decode(
+            "MIIFFDAOBgNVHQ8BAf8EBAMCBaAwEwYKKwYBBAHWeQIEAwEB/wQCBQAwHQYDVR0lBBY".
+            "wFAYIKwYBBQUHAwEGCCsGAQUFBwMCMIIBXQYDVR0gBIIBVDCCAVAwggE3Bg8rBgEEAY".
+            "GoGAIBAYEqAgkwggEiMCYGCCsGAQUFBwIBFhpodHRwOi8vY3AuZS1zemlnbm8uaHUvc".
+            "WNwczBEBggrBgEFBQcCAjA4DDZRdWFsaWZpZWQgUFNEMiBjZXJ0aWZpY2F0ZSBmb3Ig".
+            "d2Vic2l0ZSBhdXRoZW50aWNhdGlvbi4wNAYIKwYBBQUHAgIwKAwmT3JnYW5pemF0aW9".
+            "uYWwgdmFsaWRhdGlvbiBjZXJ0aWZpY2F0ZS4wRQYIKwYBBQUHAgIwOQw3TWluxZFzw6".
+            "10ZXR0IFBTRDIgd2Vib2xkYWwtaGl0ZWxlc8OtdMWRIHRhbsO6c8OtdHbDoW55LjA1B".
+            "ggrBgEFBQcCAjApDCdTemVydmV6ZXQtZWxsZW7FkXJ6w7Z0dCB0YW7DunPDrXR2w6Fu".
+            "eS4wCQYHBACBmCcDATAIBgZngQwBAgIwHQYDVR0OBBYEFCI7XaCk9Uctd6iTKpvkp0m".
+            "19TRqMB8GA1UdIwQYMBaAFH2ETsLUa+rB1yKMaMPpoPTsmIocMCgGA1UdEQQhMB+CHX".
+            "BzZDJodWIucXdhYy5jbGllbnQuYXBpLmtoLmh1MIG2BgNVHR8Ega4wgaswN6A1oDOGM".
+            "Wh0dHA6Ly9xdGxzY2EyMDE4LWNybDEuZS1zemlnbm8uaHUvcXRsc2NhMjAxOC5jcmww".
+            "N6A1oDOGMWh0dHA6Ly9xdGxzY2EyMDE4LWNybDIuZS1zemlnbm8uaHUvcXRsc2NhMjA".
+            "xOC5jcmwwN6A1oDOGMWh0dHA6Ly9xdGxzY2EyMDE4LWNybDMuZS1zemlnbm8uaHUvcX".
+            "Rsc2NhMjAxOC5jcmwwggFfBggrBgEFBQcBAQSCAVEwggFNMC8GCCsGAQUFBzABhiNod".
+            "HRwOi8vcXRsc2NhMjAxOC1vY3NwMS5lLXN6aWduby5odTAvBggrBgEFBQcwAYYjaHR0".
+            "cDovL3F0bHNjYTIwMTgtb2NzcDIuZS1zemlnbm8uaHUwLwYIKwYBBQUHMAGGI2h0dHA".
+            "6Ly9xdGxzY2EyMDE4LW9jc3AzLmUtc3ppZ25vLmh1MDwGCCsGAQUFBzAChjBodHRwOi".
+            "8vcXRsc2NhMjAxOC1jYTEuZS1zemlnbm8uaHUvcXRsc2NhMjAxOC5jcnQwPAYIKwYBB".
+            "QUHMAKGMGh0dHA6Ly9xdGxzY2EyMDE4LWNhMi5lLXN6aWduby5odS9xdGxzY2EyMDE4".
+            "LmNydDA8BggrBgEFBQcwAoYwaHR0cDovL3F0bHNjYTIwMTgtY2EzLmUtc3ppZ25vLmh".
+            "1L3F0bHNjYTIwMTguY3J0MIHmBggrBgEFBQcBAwSB2TCB1jAIBgYEAI5GAQEwCwYGBA".
+            "CORgEDAgEKMFMGBgQAjkYBBTBJMCQWHmh0dHBzOi8vY3AuZS1zemlnbm8uaHUvcWNwc".
+            "19lbhMCRU4wIRYbaHR0cHM6Ly9jcC5lLXN6aWduby5odS9xY3BzEwJIVTATBgYEAI5G".
+            "AQYwCQYHBACORgEGAzBTBgYEAIGYJwIwSTAmMBEGBwQAgZgnAQIMBlBTUF9QSTARBgc".
+            "EAIGYJwEDDAZQU1BfQUkMF0NlbnRyYWwgQmFuayBvZiBIdW5nYXJ5DAZIVS1DQkg="
+        );
         $extensions = new Extensions($extensionsDER);
         $this->assertEquals(
             [
@@ -47,7 +60,10 @@ class ExtensionTest extends TestCase
     public function testCRLDistributionPoints()
     {
         $this->assertTrue(true);
-        $binary = base64_decode('MIGrMDegNaAzhjFodHRwOi8vcXRsc2NhMjAxOC1jcmwxLmUtc3ppZ25vLmh1L3F0bHNjYTIwMTguY3JsMDegNaAzhjFodHRwOi8vcXRsc2NhMjAxOC1jcmwyLmUtc3ppZ25vLmh1L3F0bHNjYTIwMTguY3JsMDegNaAzhjFodHRwOi8vcXRsc2NhMjAxOC1jcmwzLmUtc3ppZ25vLmh1L3F0bHNjYTIwMTguY3Js');
+        $binary = base64_decode('MIGrMDegNaAzhjFodHRwOi8vcXRsc2NhMjAxOC1jcmwxL'.
+        'mUtc3ppZ25vLmh1L3F0bHNjYTIwMTguY3JsMDegNaAzhjFodHRwOi8vcXRsc2NhMjAxOC'.
+        '1jcmwyLmUtc3ppZ25vLmh1L3F0bHNjYTIwMTguY3JsMDegNaAzhjFodHRwOi8vcXRsc2N'.
+        'hMjAxOC1jcmwzLmUtc3ppZ25vLmh1L3F0bHNjYTIwMTguY3Js');
         $extnCDPs = new CRLDistributionPoints($binary);
         $this->assertEquals(
             $extnCDPs->getCDPs(),
@@ -55,6 +71,25 @@ class ExtensionTest extends TestCase
             'http://qtlsca2018-crl1.e-szigno.hu/qtlsca2018.crl',
             'http://qtlsca2018-crl2.e-szigno.hu/qtlsca2018.crl',
             'http://qtlsca2018-crl3.e-szigno.hu/qtlsca2018.crl'
+          ]
+        );
+    }
+
+    public function testExtendedKeyUsage()
+    {
+        $this->assertTrue(true);
+        $binary = base64_decode('MBQGCCsGAQUFBwMBBggrBgEFBQcDAg==');
+        $eku = new ExtendedKeyUsage($binary);
+        $this->assertEquals(
+            [
+            $eku->forPurpose('serverAuth'),
+            $eku->forPurpose('clientAuth'),
+            $eku->forPurpose('codeSigning')
+          ],
+            [
+            true,
+            true,
+            false
           ]
         );
     }


### PR DESCRIPTION
Parse extensions and refuse to process if an unrecognised `critical` extension is found as required in https://tools.ietf.org/html/rfc5280#section-4.2